### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/WinnieHsu0417/a3696ce3-7d95-43ee-8dc0-939667cebf1c/9e40783a-d701-45bd-8057-4d135b4898ce/_apis/work/boardbadge/07d935ad-2e2b-4d33-942b-4820257dafde)](https://dev.azure.com/WinnieHsu0417/a3696ce3-7d95-43ee-8dc0-939667cebf1c/_boards/board/t/9e40783a-d701-45bd-8057-4d135b4898ce/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2170](https://dev.azure.com/WinnieHsu0417/a3696ce3-7d95-43ee-8dc0-939667cebf1c/_workitems/edit/2170). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.